### PR TITLE
feat: add Ethereum chain support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,12 @@ export AWS_REGION=''
 export AWS_ACCESS_KEY_ID=''
 export AWS_SECRET_ACCESS_KEY=''
 export SOLANA_RPC_URL=''
+export ETH_RPC_URL=''  # Ethereum RPC (Alchemy/Infura recommended)
+
+# The Graph subgraph URLs (optional — defaults are provided)
+# Production usage requires a Graph API key: https://thegraph.com/studio/
+export UNISWAP_V3_SUBGRAPH_URL=''
+export AAVE_V3_SUBGRAPH_URL=''
 export OPENROUTER_API_KEY=''
 export GEMINI_API_KEY=''
 export DD_API_KEY=''

--- a/agent/tools.py
+++ b/agent/tools.py
@@ -44,7 +44,7 @@ async def retrieve_solana_pools(
 
     # Create a query to filter pools
     query = PoolQuery(
-        chain=Chain.SOLANA,  # Currently only supporting Solana
+        chain=Chain.SOLANA,
         tokens=tokens or [],
         user_tokens=user_tokens,
     )
@@ -56,9 +56,37 @@ async def retrieve_solana_pools(
     return pools
 
 
+@tool
+@track_tool_usage("retrieve_ethereum_pools")
+async def retrieve_ethereum_pools(
+    tokens: List[str] = None,
+    config: RunnableConfig = None,
+) -> List[Pool]:
+    """
+    Retrieves Ethereum pools matching the specified criteria that the user can invest in.
+    Includes Uniswap V3 AMM pools and Aave V3 lending pools.
+    """
+    configurable = config["configurable"]
+    user_tokens: List[WalletTokenHolding] = configurable["tokens"]
+    protocol_registry: ProtocolRegistry = configurable["protocol_registry"]
+
+    query = PoolQuery(
+        chain=Chain.ETHEREUM,
+        tokens=tokens or [],
+        user_tokens=user_tokens,
+    )
+
+    pools = await protocol_registry.get_pools(query)
+    if len(pools) == 0:
+        return "No Ethereum pools found."
+
+    return pools
+
+
 def create_investor_agent_toolkit() -> List[BaseTool]:
     return [
         retrieve_solana_pools,
+        retrieve_ethereum_pools,
     ]
 
 

--- a/main.py
+++ b/main.py
@@ -19,12 +19,16 @@ from server.fastapi_server import create_fastapi_app
 from onchain.pools.solana.orca_protocol import OrcaProtocol
 from onchain.pools.solana.save_protocol import SaveProtocol
 from onchain.pools.solana.kamino_protocol import KaminoProtocol
+from onchain.pools.ethereum.uniswap_v3_protocol import UniswapV3Protocol
+from onchain.pools.ethereum.aave_protocol import AaveProtocol
 
 # Define protocols enabled
 protocols = [
     OrcaProtocol.PROTOCOL_NAME,
     SaveProtocol.PROTOCOL_NAME,
     KaminoProtocol.PROTOCOL_NAME,
+    UniswapV3Protocol.PROTOCOL_NAME,
+    AaveProtocol.PROTOCOL_NAME,
 ]
 
 # Create the FastAPI app

--- a/onchain/pools/ethereum/aave_protocol.py
+++ b/onchain/pools/ethereum/aave_protocol.py
@@ -1,0 +1,162 @@
+"""Aave V3 protocol implementation for Ethereum lending pool discovery."""
+
+from typing import List, Optional, Dict, Any
+import logging
+import os
+
+import aiohttp
+
+from api.api_types import Pool, Token, Chain, PoolType
+from onchain.pools.protocol import Protocol
+from onchain.tokens.metadata import TokenMetadataRepo
+
+logger = logging.getLogger(__name__)
+
+# Aave V3 Ethereum subgraph — configurable via env var.
+AAVE_V3_SUBGRAPH_URL = os.environ.get(
+    "AAVE_V3_SUBGRAPH_URL",
+    "https://gateway.thegraph.com/api/subgraphs/id/Cd2gEDVeqnjBn1hSeqFMitw8Q1iiyV9FYUZkLNRcL87g",
+)
+
+# Stablecoins for classification
+STABLECOIN_SYMBOLS = {"USDC", "USDT", "DAI", "BUSD", "TUSD", "FRAX", "LUSD", "GUSD", "sUSD"}
+
+
+class AaveProtocol(Protocol):
+    """
+    Aave V3 protocol — fetches Ethereum lending reserves.
+
+    Returns each reserve as a lending Pool with supply APR.
+    Uses The Graph subgraph for on-chain data.
+    """
+
+    PROTOCOL_NAME = "aave-v3"
+
+    _session: Optional[aiohttp.ClientSession] = None
+
+    @property
+    def name(self) -> str:
+        return self.PROTOCOL_NAME
+
+    @property
+    async def session(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=30)
+            )
+        return self._session
+
+    async def close(self):
+        if self._session:
+            await self._session.close()
+            self._session = None
+
+    async def get_pools(self, token_metadata_repo: TokenMetadataRepo) -> List[Pool]:
+        """Fetch Aave V3 reserves from the subgraph."""
+        query = """
+        {
+            reserves(
+                first: 50,
+                where: { isActive: true }
+            ) {
+                id
+                symbol
+                name
+                decimals
+                underlyingAsset
+                liquidityRate
+                totalATokenSupply
+                totalCurrentVariableDebt
+                availableLiquidity
+                price {
+                    priceInEth
+                }
+            }
+        }
+        """
+
+        try:
+            session = await self.session
+            async with session.post(
+                AAVE_V3_SUBGRAPH_URL,
+                json={"query": query},
+            ) as response:
+                if response.status in (401, 403):
+                    logger.error(
+                        f"Aave V3 subgraph auth failed ({response.status}). "
+                        f"Set AAVE_V3_SUBGRAPH_URL with a valid Graph API key."
+                    )
+                    return []
+                if response.status != 200:
+                    logger.error(f"Aave V3 subgraph returned {response.status}")
+                    return []
+                data = await response.json()
+        except Exception as e:
+            logger.error(f"Error fetching Aave V3 reserves: {e}")
+            return []
+
+        reserves = data.get("data", {}).get("reserves", [])
+
+        # Resolve ETH/USD price for TVL conversion.
+        # Use the WETH token metadata from DexScreener (already cached).
+        eth_usd_price = 0.0
+        eth_meta = await token_metadata_repo.get_token_metadata(
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", "ethereum"
+        )
+        if eth_meta and eth_meta.price:
+            eth_usd_price = float(eth_meta.price)
+
+        return self._convert_to_pools(reserves, eth_usd_price)
+
+    def _convert_to_pools(
+        self, reserves: List[Dict[str, Any]], eth_usd_price: float
+    ) -> List[Pool]:
+        result: List[Pool] = []
+
+        for reserve in reserves:
+            symbol = reserve.get("symbol", "")
+            name = reserve.get("name", "")
+            address = reserve.get("underlyingAsset", "")
+            decimals = int(reserve.get("decimals", 18))
+
+            tokens = [
+                Token(address=address, name=name, symbol=symbol),
+            ]
+
+            # Aave liquidityRate is in RAY units (1e27), convert to APR percentage
+            liquidity_rate = int(reserve.get("liquidityRate", 0))
+            supply_apr = (liquidity_rate / 1e27) * 100
+
+            # Calculate TVL in USD:
+            #   totalATokenSupply is in token-native units (needs /10^decimals)
+            #   priceInEth is the token price denominated in ETH (wei-scaled, 1e18)
+            #   Multiply by eth_usd_price to get USD
+            total_supply_raw = int(reserve.get("totalATokenSupply", 0))
+            total_supply = total_supply_raw / (10**decimals)
+
+            price_in_eth_raw = reserve.get("price", {}).get("priceInEth", "0")
+            price_in_eth = int(price_in_eth_raw) / 1e18
+
+            if eth_usd_price > 0 and price_in_eth > 0:
+                tvl_usd = str(round(total_supply * price_in_eth * eth_usd_price, 2))
+            else:
+                tvl_usd = str(round(total_supply, 2))
+
+            is_stablecoin = symbol.upper() in STABLECOIN_SYMBOLS
+
+            pool = Pool(
+                id=reserve.get("id", ""),
+                chain=Chain.ETHEREUM,
+                protocol="Aave V3",
+                tokens=tokens,
+                type=PoolType.LENDING,
+                TVL=tvl_usd,
+                APRLastDay=round(supply_apr, 2),
+                APRLastWeek=round(supply_apr, 2),
+                APRLastMonth=round(supply_apr, 2),
+                isStableCoin=is_stablecoin,
+                impermanentLossRisk=False,  # Lending has no IL
+            )
+            result.append(pool)
+
+        return result

--- a/onchain/pools/ethereum/test_ethereum_protocols.py
+++ b/onchain/pools/ethereum/test_ethereum_protocols.py
@@ -1,0 +1,126 @@
+import unittest
+import os
+import boto3
+import asyncio
+
+from onchain.pools.ethereum.uniswap_v3_protocol import UniswapV3Protocol
+from onchain.pools.ethereum.aave_protocol import AaveProtocol
+from onchain.portfolio.ethereum_portfolio import EthereumPortfolioFetcher
+from onchain.tokens.metadata import TokenMetadataRepo
+from api.api_types import Chain, PoolType
+import dotenv
+
+dotenv.load_dotenv()
+
+
+class TestEthereumProtocols(unittest.TestCase):
+    def setUp(self):
+        dynamodb = boto3.resource(
+            "dynamodb",
+            region_name=os.environ.get("AWS_REGION"),
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        )
+        tokens_table = dynamodb.Table("token_metadata_v2")
+        self.token_metadata_repo = TokenMetadataRepo(tokens_table)
+
+    def test_uniswap_v3(self):
+        uniswap = UniswapV3Protocol()
+        pools = asyncio.run(uniswap.get_pools(self.token_metadata_repo))
+
+        self.assertGreater(len(pools), 5)
+        print(f"Uniswap V3 pools: {len(pools)}")
+
+        # Verify pool structure
+        for pool in pools[:3]:
+            self.assertEqual(pool.chain, Chain.ETHEREUM)
+            self.assertEqual(pool.type, PoolType.AMM)
+            self.assertIn("Uniswap V3", pool.protocol)
+            self.assertEqual(len(pool.tokens), 2)
+            self.assertIsNotNone(pool.TVL)
+            self.assertGreaterEqual(pool.APRLastDay, 0)
+
+    def test_uniswap_v3_stablecoin_detection(self):
+        uniswap = UniswapV3Protocol()
+        pools = asyncio.run(uniswap.get_pools(self.token_metadata_repo))
+
+        # Non-stablecoin pools should have IL risk
+        for pool in pools:
+            if not pool.isStableCoin:
+                self.assertTrue(pool.impermanentLossRisk)
+            else:
+                self.assertFalse(pool.impermanentLossRisk)
+
+    def test_aave_v3(self):
+        aave = AaveProtocol()
+        pools = asyncio.run(aave.get_pools(self.token_metadata_repo))
+
+        self.assertGreater(len(pools), 5)
+        print(f"Aave V3 reserves: {len(pools)}")
+
+        # Verify pool structure
+        for pool in pools[:3]:
+            self.assertEqual(pool.chain, Chain.ETHEREUM)
+            self.assertEqual(pool.type, PoolType.LENDING)
+            self.assertEqual(pool.protocol, "Aave V3")
+            self.assertEqual(len(pool.tokens), 1)
+            self.assertFalse(pool.impermanentLossRisk)
+            self.assertGreaterEqual(pool.APRLastDay, 0)
+
+    def test_aave_v3_tvl_is_usd(self):
+        """TVL should be in USD (not raw token units)."""
+        aave = AaveProtocol()
+        pools = asyncio.run(aave.get_pools(self.token_metadata_repo))
+
+        for pool in pools:
+            tvl = float(pool.TVL)
+            # Any active Aave reserve should have meaningful TVL in USD
+            if tvl > 0:
+                self.assertGreater(tvl, 100, f"{pool.tokens[0].symbol} TVL too low: {tvl}")
+
+
+class TestEthereumPortfolio(unittest.TestCase):
+    def setUp(self):
+        dynamodb = boto3.resource(
+            "dynamodb",
+            region_name=os.environ.get("AWS_REGION"),
+            aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        )
+        tokens_table = dynamodb.Table("token_metadata_v2")
+        self.token_metadata_repo = TokenMetadataRepo(tokens_table)
+        self.portfolio_fetcher = EthereumPortfolioFetcher(self.token_metadata_repo)
+
+    def tearDown(self):
+        asyncio.run(self.portfolio_fetcher.close())
+
+    def test_get_portfolio(self):
+        # Vitalik's public wallet
+        portfolio = asyncio.run(
+            self.portfolio_fetcher.get_portfolio(
+                "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+            )
+        )
+        print(portfolio)
+
+        self.assertGreater(len(portfolio.holdings), 0)
+        # Vitalik holds ETH
+        eth_holdings = [h for h in portfolio.holdings if h.symbol == "ETH"]
+        self.assertEqual(len(eth_holdings), 1)
+        self.assertGreater(eth_holdings[0].amount, 0)
+
+    def test_empty_wallet(self):
+        # Zero address should have no holdings
+        portfolio = asyncio.run(
+            self.portfolio_fetcher.get_portfolio(
+                "0x0000000000000000000000000000000000000001"
+            )
+        )
+        self.assertEqual(len(portfolio.holdings), 0)
+
+    def test_invalid_address(self):
+        portfolio = asyncio.run(
+            self.portfolio_fetcher.get_portfolio("not-a-valid-address")
+        )
+        self.assertEqual(len(portfolio.holdings), 0)
+        self.assertEqual(portfolio.total_value_usd, 0)

--- a/onchain/pools/ethereum/uniswap_v3_protocol.py
+++ b/onchain/pools/ethereum/uniswap_v3_protocol.py
@@ -1,0 +1,191 @@
+"""Uniswap V3 protocol implementation for Ethereum pool discovery."""
+
+from typing import List, Optional, Dict, Any
+import logging
+import os
+
+import aiohttp
+
+from api.api_types import Pool, Token, Chain, PoolType
+from onchain.pools.protocol import Protocol
+from onchain.tokens.metadata import TokenMetadataRepo
+
+logger = logging.getLogger(__name__)
+
+# Uniswap V3 subgraph endpoint — configurable via env var.
+# The Graph gateway requires an API key appended as a query param or header
+# for production use. Set UNISWAP_V3_SUBGRAPH_URL to override.
+UNISWAP_V3_SUBGRAPH_URL = os.environ.get(
+    "UNISWAP_V3_SUBGRAPH_URL",
+    "https://gateway.thegraph.com/api/subgraphs/id/5zvR82QoaXYFyDEKLZ9t6v9adgnptxYpKpSbxtgVENFV",
+)
+
+# Fee tier mapping (hundredths of a bip -> percentage)
+FEE_TIER_MAP = {
+    100: 0.01,
+    500: 0.05,
+    3000: 0.30,
+    10000: 1.00,
+}
+
+# Stablecoin symbols for pool classification
+STABLECOIN_SYMBOLS = {"USDC", "USDT", "DAI", "BUSD", "TUSD", "FRAX", "LUSD", "GUSD", "sUSD"}
+
+
+class UniswapV3Protocol(Protocol):
+    """
+    Uniswap V3 protocol — fetches top Ethereum liquidity pools by TVL.
+
+    Uses The Graph's hosted subgraph for pool data. Calculates APR
+    from historical fee revenue relative to pool liquidity.
+    """
+
+    PROTOCOL_NAME = "uniswap-v3"
+    MAX_POOLS = 100
+
+    _session: Optional[aiohttp.ClientSession] = None
+
+    @property
+    def name(self) -> str:
+        return self.PROTOCOL_NAME
+
+    @property
+    async def session(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            self._session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=30)
+            )
+        return self._session
+
+    async def close(self):
+        if self._session:
+            await self._session.close()
+            self._session = None
+
+    async def get_pools(self, token_metadata_repo: TokenMetadataRepo) -> List[Pool]:
+        """Fetch top Uniswap V3 pools from the subgraph."""
+        query = """
+        {
+            pools(
+                first: %d,
+                orderBy: totalValueLockedUSD,
+                orderDirection: desc,
+                where: { totalValueLockedUSD_gt: "100000" }
+            ) {
+                id
+                token0 { id symbol name }
+                token1 { id symbol name }
+                feeTier
+                totalValueLockedUSD
+                poolDayData(first: 30, orderBy: date, orderDirection: desc) {
+                    date
+                    feesUSD
+                    tvlUSD
+                }
+            }
+        }
+        """ % self.MAX_POOLS
+
+        try:
+            session = await self.session
+            async with session.post(
+                UNISWAP_V3_SUBGRAPH_URL,
+                json={"query": query},
+            ) as response:
+                if response.status in (401, 403):
+                    logger.error(
+                        f"Uniswap V3 subgraph auth failed ({response.status}). "
+                        f"Set UNISWAP_V3_SUBGRAPH_URL with a valid Graph API key."
+                    )
+                    return []
+                if response.status != 200:
+                    logger.error(f"Uniswap V3 subgraph returned {response.status}")
+                    return []
+                data = await response.json()
+        except Exception as e:
+            logger.error(f"Error fetching Uniswap V3 pools: {e}")
+            return []
+
+        pools_data = data.get("data", {}).get("pools", [])
+        return self._convert_to_pools(pools_data)
+
+    def _convert_to_pools(self, subgraph_pools: List[Dict[str, Any]]) -> List[Pool]:
+        result: List[Pool] = []
+
+        for pool_data in subgraph_pools:
+            token0 = pool_data.get("token0", {})
+            token1 = pool_data.get("token1", {})
+
+            tokens = [
+                Token(
+                    address=token0.get("id", ""),
+                    name=token0.get("name", ""),
+                    symbol=token0.get("symbol", ""),
+                ),
+                Token(
+                    address=token1.get("id", ""),
+                    name=token1.get("name", ""),
+                    symbol=token1.get("symbol", ""),
+                ),
+            ]
+
+            tvl_usd = pool_data.get("totalValueLockedUSD", "0")
+
+            # Calculate APR from fee revenue
+            day_data = pool_data.get("poolDayData", [])
+            apr_1d = self._calculate_apr(day_data, days=1)
+            apr_7d = self._calculate_apr(day_data, days=7)
+            apr_30d = self._calculate_apr(day_data, days=30)
+
+            is_stablecoin = self._is_stablecoin_pool(tokens)
+
+            fee_tier = int(pool_data.get("feeTier", 0))
+            fee_pct = FEE_TIER_MAP.get(fee_tier, 0)
+            protocol_label = f"Uniswap V3 ({fee_pct}%)"
+
+            pool = Pool(
+                id=pool_data.get("id", ""),
+                chain=Chain.ETHEREUM,
+                protocol=protocol_label,
+                tokens=tokens,
+                type=PoolType.AMM,
+                TVL=tvl_usd,
+                APRLastDay=apr_1d,
+                APRLastWeek=apr_7d,
+                APRLastMonth=apr_30d,
+                isStableCoin=is_stablecoin,
+                impermanentLossRisk=not is_stablecoin,
+            )
+            result.append(pool)
+
+        return result
+
+    def _calculate_apr(
+        self, day_data: List[Dict[str, Any]], days: int = 1
+    ) -> float:
+        """Calculate annualized APR from poolDayData fee revenue."""
+        try:
+            if not day_data or len(day_data) == 0:
+                return 0.0
+
+            # Use up to `days` entries (already sorted desc by date)
+            entries = day_data[:days]
+            if not entries:
+                return 0.0
+
+            total_fees = sum(float(d.get("feesUSD", 0)) for d in entries)
+            avg_tvl = sum(float(d.get("tvlUSD", 0)) for d in entries) / len(entries)
+
+            if avg_tvl <= 0:
+                return 0.0
+
+            daily_yield = total_fees / len(entries) / avg_tvl
+            apr = daily_yield * 365 * 100
+            return round(apr, 2)
+        except (ValueError, TypeError, ZeroDivisionError):
+            return 0.0
+
+    def _is_stablecoin_pool(self, tokens: List[Token]) -> bool:
+        if not tokens:
+            return False
+        return all(t.symbol.upper() in STABLECOIN_SYMBOLS for t in tokens)

--- a/onchain/portfolio/ethereum_portfolio.py
+++ b/onchain/portfolio/ethereum_portfolio.py
@@ -1,0 +1,304 @@
+"""Ethereum portfolio fetcher using web3.py for native ETH + ERC20 token balances.
+
+Supports two modes:
+- **Alchemy mode** (recommended): When ETH_RPC_URL points to an Alchemy endpoint,
+  uses ``alchemy_getTokenBalances`` for complete ERC20 coverage in a single call.
+- **Fallback mode**: Queries ``balanceOf`` for a curated list of well-known tokens.
+"""
+
+from typing import List, Optional, Dict, Any
+import logging
+import os
+
+import aiohttp
+from async_lru import alru_cache
+from web3 import AsyncWeb3, AsyncHTTPProvider
+from web3.contract import AsyncContract
+
+from onchain.tokens.metadata import TokenMetadataRepo, WETH_ADDRESS
+from api.api_types import WalletTokenHolding, Portfolio
+
+logger = logging.getLogger(__name__)
+
+# Minimal ERC20 ABI for balanceOf and decimals
+ERC20_ABI = [
+    {
+        "constant": True,
+        "inputs": [{"name": "_owner", "type": "address"}],
+        "name": "balanceOf",
+        "outputs": [{"name": "balance", "type": "uint256"}],
+        "type": "function",
+    },
+    {
+        "constant": True,
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [{"name": "", "type": "uint8"}],
+        "type": "function",
+    },
+]
+
+# Well-known ERC20 tokens — only used as a fallback when Alchemy is not the
+# RPC provider. When ETH_RPC_URL points to Alchemy, `alchemy_getTokenBalances`
+# discovers all ERC20 holdings automatically, making this list unnecessary.
+# address -> decimals
+WELL_KNOWN_TOKENS: Dict[str, int] = {
+    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": 6,   # USDC
+    "0xdAC17F958D2ee523a2206206994597C13D831ec7": 6,   # USDT
+    "0x6B175474E89094C44Da98b954EedeAC495271d0F": 18,  # DAI
+    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": 18,  # WETH
+    "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599": 8,   # WBTC
+    "0x514910771AF9Ca656af840dff83E8264EcF986CA": 18,  # LINK
+    "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984": 18,  # UNI
+    "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9": 18,  # AAVE
+    "0xD533a949740bb3306d119CC777fa900bA034cd52": 18,  # CRV
+    "0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84": 18,  # stETH
+}
+
+
+def _is_alchemy_url(url: str) -> bool:
+    """Check if the RPC URL is an Alchemy endpoint."""
+    return "alchemy" in url.lower()
+
+
+class EthereumPortfolioFetcher:
+    """Fetches Ethereum wallet portfolio via Alchemy enhanced API or web3.py fallback."""
+
+    ETH_RPC_URL = os.environ.get("ETH_RPC_URL", "")
+
+    def __init__(self, token_metadata_repo: TokenMetadataRepo):
+        self.token_metadata_repo = token_metadata_repo
+        self._w3: Optional[AsyncWeb3] = None
+        self._http_session: Optional[aiohttp.ClientSession] = None
+        self._use_alchemy = _is_alchemy_url(self.ETH_RPC_URL)
+
+    @property
+    def w3(self) -> AsyncWeb3:
+        if self._w3 is None:
+            if not self.ETH_RPC_URL:
+                raise ValueError("ETH_RPC_URL environment variable is not set")
+            self._w3 = AsyncWeb3(AsyncHTTPProvider(self.ETH_RPC_URL))
+        return self._w3
+
+    @property
+    async def http_session(self) -> aiohttp.ClientSession:
+        if self._http_session is None:
+            self._http_session = aiohttp.ClientSession(
+                timeout=aiohttp.ClientTimeout(total=15)
+            )
+        return self._http_session
+
+    async def close(self):
+        """Clean up sessions."""
+        if self._http_session and not self._http_session.closed:
+            await self._http_session.close()
+            self._http_session = None
+        if self._w3 and hasattr(self._w3.provider, "_session"):
+            session = self._w3.provider._session
+            if session and not session.closed:
+                await session.close()
+        self._w3 = None
+
+    @alru_cache(maxsize=100_000, ttl=60 * 60)
+    async def get_portfolio(self, wallet_address: str) -> Portfolio:
+        """Get the complete portfolio of token holdings for an Ethereum wallet."""
+        if not wallet_address:
+            return Portfolio(holdings=[], total_value_usd=0)
+
+        try:
+            address = self.w3.to_checksum_address(wallet_address)
+        except Exception:
+            logger.error(f"Invalid Ethereum address: {wallet_address}")
+            return Portfolio(holdings=[], total_value_usd=0)
+
+        holdings: List[WalletTokenHolding] = []
+
+        # Get native ETH balance
+        eth_holding = await self._get_eth_holding(address)
+        if eth_holding:
+            holdings.append(eth_holding)
+
+        # Get ERC20 token balances — prefer Alchemy for complete coverage
+        if self._use_alchemy:
+            erc20_holdings = await self._get_alchemy_token_balances(address)
+        else:
+            erc20_holdings = await self._get_fallback_token_balances(address)
+
+        holdings.extend(erc20_holdings)
+
+        portfolio_value = sum(h.total_value_usd or 0 for h in holdings)
+        return Portfolio(holdings=holdings, total_value_usd=portfolio_value)
+
+    # ── Native ETH ──────────────────────────────────────────────
+
+    async def _get_eth_holding(
+        self, wallet_address: str
+    ) -> Optional[WalletTokenHolding]:
+        """Get the native ETH holding for a wallet."""
+        try:
+            balance_wei = await self.w3.eth.get_balance(wallet_address)
+            if balance_wei == 0:
+                return None
+
+            eth_amount = balance_wei / 1e18
+
+            metadata = await self.token_metadata_repo.get_token_metadata(
+                WETH_ADDRESS, "ethereum"
+            )
+            if metadata and metadata.price:
+                value_usd = float(eth_amount) * float(metadata.price)
+            else:
+                value_usd = None
+
+            return WalletTokenHolding(
+                address=WETH_ADDRESS,
+                amount=eth_amount,
+                symbol="ETH",
+                name="Ethereum",
+                total_value_usd=value_usd,
+            )
+        except Exception as e:
+            logger.error(f"Error fetching ETH balance: {e}")
+            return None
+
+    # ── Alchemy enhanced API ────────────────────────────────────
+
+    async def _get_alchemy_token_balances(
+        self, wallet_address: str
+    ) -> List[WalletTokenHolding]:
+        """Fetch all ERC20 balances in a single Alchemy RPC call."""
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "alchemy_getTokenBalances",
+            "params": [wallet_address, "DEFAULT_TOKENS"],
+        }
+
+        try:
+            session = await self.http_session
+            async with session.post(
+                self.ETH_RPC_URL, json=payload
+            ) as response:
+                if response.status != 200:
+                    logger.warning(
+                        f"Alchemy getTokenBalances returned {response.status}, "
+                        f"falling back to individual queries"
+                    )
+                    return await self._get_fallback_token_balances(wallet_address)
+
+                data = await response.json()
+        except Exception as e:
+            logger.warning(f"Alchemy API error: {e}, falling back")
+            return await self._get_fallback_token_balances(wallet_address)
+
+        result_obj = data.get("result", {})
+        token_balances = result_obj.get("tokenBalances", [])
+
+        holdings: List[WalletTokenHolding] = []
+        for tb in token_balances:
+            token_address = tb.get("contractAddress", "")
+            hex_balance = tb.get("tokenBalance", "0x0")
+
+            balance_raw = int(hex_balance, 16)
+            if balance_raw == 0:
+                continue
+
+            # Fetch metadata (includes price) from DexScreener
+            metadata = await self.token_metadata_repo.get_token_metadata(
+                token_address, "ethereum"
+            )
+            if metadata is None:
+                continue
+
+            # Get decimals — try well-known map first, then on-chain call
+            decimals = WELL_KNOWN_TOKENS.get(token_address)
+            if decimals is None:
+                decimals = await self._get_token_decimals(token_address)
+
+            amount = balance_raw / (10**decimals)
+
+            if metadata.price:
+                value_usd = float(amount) * float(metadata.price)
+            else:
+                value_usd = None
+
+            holdings.append(
+                WalletTokenHolding(
+                    address=token_address,
+                    amount=amount,
+                    symbol=metadata.symbol,
+                    name=metadata.name,
+                    image_url=metadata.image_url,
+                    total_value_usd=value_usd,
+                )
+            )
+
+        return holdings
+
+    async def _get_token_decimals(self, token_address: str) -> int:
+        """Query ERC20 decimals() on-chain. Defaults to 18 on failure."""
+        try:
+            checksum = self.w3.to_checksum_address(token_address)
+            contract: AsyncContract = self.w3.eth.contract(
+                address=checksum, abi=ERC20_ABI
+            )
+            return await contract.functions.decimals().call()
+        except Exception:
+            return 18
+
+    # ── Fallback: individual balanceOf calls ────────────────────
+
+    async def _get_fallback_token_balances(
+        self, wallet_address: str
+    ) -> List[WalletTokenHolding]:
+        """Query balanceOf for each well-known token individually."""
+        holdings: List[WalletTokenHolding] = []
+        for token_address, decimals in WELL_KNOWN_TOKENS.items():
+            holding = await self._get_erc20_holding(
+                wallet_address, token_address, decimals
+            )
+            if holding:
+                holdings.append(holding)
+        return holdings
+
+    async def _get_erc20_holding(
+        self,
+        wallet_address: str,
+        token_address: str,
+        decimals: int,
+    ) -> Optional[WalletTokenHolding]:
+        """Get a single ERC20 token holding for a wallet."""
+        try:
+            checksum_token = self.w3.to_checksum_address(token_address)
+            contract: AsyncContract = self.w3.eth.contract(
+                address=checksum_token, abi=ERC20_ABI
+            )
+
+            balance = await contract.functions.balanceOf(wallet_address).call()
+            if balance == 0:
+                return None
+
+            amount = balance / (10**decimals)
+
+            metadata = await self.token_metadata_repo.get_token_metadata(
+                token_address, "ethereum"
+            )
+            if metadata is None:
+                return None
+
+            if metadata.price:
+                value_usd = float(amount) * float(metadata.price)
+            else:
+                value_usd = None
+
+            return WalletTokenHolding(
+                address=token_address,
+                amount=amount,
+                symbol=metadata.symbol,
+                name=metadata.name,
+                image_url=metadata.image_url,
+                total_value_usd=value_usd,
+            )
+        except Exception as e:
+            logger.debug(f"Error fetching ERC20 balance for {token_address}: {e}")
+            return None

--- a/onchain/tokens/metadata.py
+++ b/onchain/tokens/metadata.py
@@ -75,6 +75,57 @@ SOL_TOKEN = TokenMetadata(
     timestamp=int(time.time()),
 )
 
+# Ethereum hardcoded tokens
+ETH_TOKEN = TokenMetadata(
+    chain="ethereum",
+    address="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    name="Ethereum",
+    symbol="ETH",
+    image_url="https://assets.coingecko.com/coins/images/279/small/ethereum.png",
+    price=1.0,
+    dex_pool_address=None,
+    market_cap_usd=None,
+    timestamp=int(time.time()),
+)
+
+USDC_ETH_TOKEN = TokenMetadata(
+    chain="ethereum",
+    address="0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+    name="USD Coin",
+    symbol="USDC",
+    image_url="https://assets.coingecko.com/coins/images/6319/small/usdc.png",
+    price=1.0,
+    dex_pool_address=None,
+    market_cap_usd=None,
+    timestamp=int(time.time()),
+)
+
+USDT_ETH_TOKEN = TokenMetadata(
+    chain="ethereum",
+    address="0xdAC17F958D2ee523a2206206994597C13D831ec7",
+    name="Tether",
+    symbol="USDT",
+    image_url="https://assets.coingecko.com/coins/images/325/small/Tether.png",
+    price=1.0,
+    dex_pool_address=None,
+    market_cap_usd=None,
+    timestamp=int(time.time()),
+)
+
+DAI_ETH_TOKEN = TokenMetadata(
+    chain="ethereum",
+    address="0x6B175474E89094C44Da98b954EedeAC495271d0F",
+    name="Dai",
+    symbol="DAI",
+    image_url="https://assets.coingecko.com/coins/images/9956/small/Badge_Dai.png",
+    price=1.0,
+    dex_pool_address=None,
+    market_cap_usd=None,
+    timestamp=int(time.time()),
+)
+
+WETH_ADDRESS = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+
 
 class TokenMetadataRepo:
     DEXSCREENER_API_URL = "https://api.dexscreener.com/tokens/v1/%s/%s"
@@ -138,6 +189,18 @@ class TokenMetadataRepo:
                 or token == SOL_TOKEN.address
             ):
                 return SOL_TOKEN
+
+        # Hardcoded Ethereum tokens
+        if chain == "ethereum":
+            token_lower = token.lower()
+            if token_lower in ("eth", "ethereum", "weth") or token_lower == ETH_TOKEN.address.lower():
+                return ETH_TOKEN
+            if token_lower in ("usdc", "usd coin") or token_lower == USDC_ETH_TOKEN.address.lower():
+                return USDC_ETH_TOKEN
+            if token_lower in ("usdt", "tether") or token_lower == USDT_ETH_TOKEN.address.lower():
+                return USDT_ETH_TOKEN
+            if token_lower in ("dai",) or token_lower == DAI_ETH_TOKEN.address.lower():
+                return DAI_ETH_TOKEN
 
         if chain is not None:
             # Check if token is a valid address

--- a/onchain/tokens/metadata.py
+++ b/onchain/tokens/metadata.py
@@ -75,14 +75,16 @@ SOL_TOKEN = TokenMetadata(
     timestamp=int(time.time()),
 )
 
-# Ethereum hardcoded tokens
+# Ethereum hardcoded tokens — price=None for ETH (non-stablecoin).
+# search_token() fetches the live price from DexScreener for ETH;
+# stablecoins use price=1.0 which is accurate.
 ETH_TOKEN = TokenMetadata(
     chain="ethereum",
     address="0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     name="Ethereum",
     symbol="ETH",
     image_url="https://assets.coingecko.com/coins/images/279/small/ethereum.png",
-    price=1.0,
+    price=None,
     dex_pool_address=None,
     market_cap_usd=None,
     timestamp=int(time.time()),
@@ -194,7 +196,9 @@ class TokenMetadataRepo:
         if chain == "ethereum":
             token_lower = token.lower()
             if token_lower in ("eth", "ethereum", "weth") or token_lower == ETH_TOKEN.address.lower():
-                return ETH_TOKEN
+                # Fetch live price from DexScreener; fall back to static token if unavailable
+                eth_meta = await self.get_token_metadata(WETH_ADDRESS, "ethereum")
+                return eth_meta if eth_meta else ETH_TOKEN
             if token_lower in ("usdc", "usd coin") or token_lower == USDC_ETH_TOKEN.address.lower():
                 return USDC_ETH_TOKEN
             if token_lower in ("usdt", "tether") or token_lower == USDT_ETH_TOKEN.address.lower():

--- a/server/fastapi_server.py
+++ b/server/fastapi_server.py
@@ -17,8 +17,11 @@ from onchain.pools.protocol import ProtocolRegistry
 from onchain.pools.solana.orca_protocol import OrcaProtocol
 from onchain.pools.solana.save_protocol import SaveProtocol
 from onchain.pools.solana.kamino_protocol import KaminoProtocol
+from onchain.pools.ethereum.uniswap_v3_protocol import UniswapV3Protocol
+from onchain.pools.ethereum.aave_protocol import AaveProtocol
 from onchain.tokens.metadata import TokenMetadataRepo
 from onchain.portfolio.solana_portfolio import PortfolioFetcher
+from onchain.portfolio.ethereum_portfolio import EthereumPortfolioFetcher
 from api.api_types import (
     AgentChatRequest,
     AgentMessage,
@@ -112,6 +115,7 @@ def create_fastapi_app() -> FastAPI:
         database_manager.table_context_factory("token_metadata_v2")
     )
     portfolio_fetcher = PortfolioFetcher(token_metadata_repo)
+    eth_portfolio_fetcher = EthereumPortfolioFetcher(token_metadata_repo)
     swap_tracker = SwapTracker(
         database_manager.table_context_factory("twoligma_processed_swaps")
     )
@@ -123,6 +127,7 @@ def create_fastapi_app() -> FastAPI:
     app.state.invite_manager = invite_manager
     app.state.token_metadata_repo = token_metadata_repo
     app.state.portfolio_fetcher = portfolio_fetcher
+    app.state.eth_portfolio_fetcher = eth_portfolio_fetcher
     app.state.swap_tracker = swap_tracker
     app.state.jup_validator = jup_validator
     app.state.cow_validator = cow_validator
@@ -132,6 +137,7 @@ def create_fastapi_app() -> FastAPI:
         await protocol_registry.shutdown()
         await token_metadata_repo.close()
         await portfolio_fetcher.close()
+        await eth_portfolio_fetcher.close()
         await jup_validator.close()
         await cow_validator.close()
 
@@ -145,6 +151,8 @@ def create_fastapi_app() -> FastAPI:
     protocol_registry.register_protocol(OrcaProtocol())
     protocol_registry.register_protocol(SaveProtocol())
     protocol_registry.register_protocol(KaminoProtocol())
+    protocol_registry.register_protocol(UniswapV3Protocol())
+    protocol_registry.register_protocol(AaveProtocol())
 
     # Store agents in app state
     app.state.suggestions_model = suggestions_model


### PR DESCRIPTION
## Summary

Adds Ethereum chain support alongside the existing Solana infrastructure, covering the three items in #48:

- **ETH portfolio analysis** — `EthereumPortfolioFetcher` with dual-mode support: auto-detects Alchemy endpoints and uses `alchemy_getTokenBalances` for complete ERC20 coverage in a single RPC call, with graceful fallback to individual `balanceOf` queries for 10 well-known tokens (USDC, USDT, DAI, WETH, WBTC, LINK, UNI, AAVE, CRV, stETH)
- **ETH token metadata** — Hardcoded ETH/USDC/USDT/DAI entries with `search_token()` shortcut matching, backed by existing DexScreener API (already chain-agnostic)
- **ETH wallet tokens** — Portfolio fetcher resolves token metadata and USD values via `TokenMetadataRepo`

Also adds Ethereum DeFi protocol implementations for pool discovery:

- **Uniswap V3** — Top 100 pools by TVL from The Graph subgraph, fee-based APR calculation across 1d/7d/30d windows, fee tier labeling (0.01%-1%)
- **Aave V3** — Active lending reserves with supply APR from on-chain `liquidityRate` (RAY units), USD-denominated TVL via `priceInEth * ETH/USD * supply`

### Architecture

Follows existing patterns exactly:
- Protocols implement `Protocol` ABC and register with `ProtocolRegistry`
- Portfolio fetcher mirrors `solana_portfolio.py` structure
- New `retrieve_ethereum_pools` tool added to investor agent toolkit
- `Chain.ETHEREUM` enum already existed — no type changes needed

### New files
- `onchain/portfolio/ethereum_portfolio.py`
- `onchain/pools/ethereum/uniswap_v3_protocol.py`
- `onchain/pools/ethereum/aave_protocol.py`
- `onchain/pools/ethereum/test_ethereum_protocols.py`

### Modified files
- `onchain/tokens/metadata.py` — ETH hardcoded tokens
- `agent/tools.py` — `retrieve_ethereum_pools` tool
- `server/fastapi_server.py` — register ETH protocols + portfolio fetcher
- `main.py` — ETH protocol names
- `.env.example` — `ETH_RPC_URL`, `UNISWAP_V3_SUBGRAPH_URL`, `AAVE_V3_SUBGRAPH_URL`

### Key improvements over initial implementation
- **Alchemy API support** — `alchemy_getTokenBalances` provides complete ERC20 token discovery without maintaining a hardcoded list; falls back gracefully to individual `balanceOf` calls for non-Alchemy RPCs
- **Configurable subgraph URLs** — Both Uniswap V3 and Aave V3 subgraph endpoints are configurable via environment variables with sensible defaults
- **Accurate Aave TVL** — Converts from token-native units to USD using `priceInEth * ETH/USD` from DexScreener, rather than raw token counts
- **Integration tests** — Full test coverage for Uniswap V3 pools, Aave V3 reserves, portfolio fetching, empty wallets, and invalid addresses

### Dependencies
- `web3>=7.3.0` — already in requirements.txt
- `aiohttp` — already in requirements.txt

## Test plan

- [x] Verify ETH token search returns hardcoded tokens (ETH, USDC, USDT, DAI)
- [x] Verify DexScreener metadata fetch works for ethereum chain
- [x] Test EthereumPortfolioFetcher with a known wallet address
- [x] Test Uniswap V3 subgraph query returns pools with valid APR
- [x] Test Aave V3 subgraph query returns lending reserves with USD TVL
- [x] Verify `retrieve_ethereum_pools` tool filters by Chain.ETHEREUM
- [x] Verify existing Solana functionality is unaffected
- [x] Test portfolio fallback mode (non-Alchemy RPC)
- [x] Test empty wallet and invalid address edge cases

Closes #48