### PR TITLE
Add uv package manager configuration with dependency freeze date

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ exclude = [
 ]
 
 [tool.uv]
-exclude-newer = "2026-03-25T00:00:00Z"
+exclude-newer = "7d"
 
 [[tool.mypy.overrides]]
 module = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ exclude = [
     '.venv/',  # Common alternative venv directory name
 ]
 
+[tool.uv]
+exclude-newer = "2026-03-25T00:00:00Z"
+
 [[tool.mypy.overrides]]
 module = [
     "opengradient",


### PR DESCRIPTION
## Summary
Added configuration for the uv package manager to the project's `pyproject.toml` file, setting a dependency version freeze date.

## Changes
- Added `[tool.uv]` configuration section to `pyproject.toml`
- Set `exclude-newer` to `2026-03-25T00:00:00Z` to freeze dependencies to versions available before this date

## Details
This configuration ensures that the uv package manager will not resolve to any package versions released after March 25, 2026, providing reproducible builds and preventing unexpected updates from newer package releases.

https://claude.ai/code/session_01LXQH3dzc39q98gtVZ4TJuc