### PR TITLE
fix sample agent request command and payload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,11 @@ chat:
 	python3.13 testclient/client.py
 
 sample:
-	curl -XPOST http://127.0.0.1:8000/api/agent/run \
+	@echo "Set FIREBASE_ID_TOKEN or SKIP_TOKEN_AUTH_HEADER/SKIP_TOKEN_AUTH_KEY before running make sample."
+	curl -XPOST http://127.0.0.1:8000/api/v2/agent/run \
 	  -H "Content-Type: application/json" \
+	  $(if $(FIREBASE_ID_TOKEN),-H "Authorization: Bearer $(FIREBASE_ID_TOKEN)") \
+	  $(if $(and $(SKIP_TOKEN_AUTH_HEADER),$(SKIP_TOKEN_AUTH_KEY)),-H "$(SKIP_TOKEN_AUTH_HEADER): $(SKIP_TOKEN_AUTH_KEY)") \
 	  -d @sample-payload.json | jq
 
 format:

--- a/sample-payload.json
+++ b/sample-payload.json
@@ -1,10 +1,12 @@
 {
-    "context": {
-        "address": "0x1234567890123456789012345678901234567890",
-        "conversationHistory": [],
-    },
-    "message": {
-        "type": "user",
-        "message": "What is the price of BTC?"
-    }
+  "context": {
+    "address": "0x1234567890123456789012345678901234567890",
+    "conversationHistory": []
+  },
+  "message": {
+    "type": "user",
+    "message": "What is the price of BTC?"
+  },
+  "agent": "analytics_agent",
+  "captchaToken": "test-captcha-token"
 }


### PR DESCRIPTION
## Summary
- update `make sample` to use the current `/api/v2/agent/run` endpoint
- make `sample-payload.json` valid JSON
- add the required `captchaToken` field to the sample payload
- allow the sample command to send either a Firebase bearer token or local skip-auth headers from env vars

## Why
The local sample request had drifted from the current FastAPI API shape:
- the Makefile sample command still pointed to the old route
- the bundled sample payload was invalid JSON
- the payload was missing fields now expected by the current request flow

## Validation
- `python -m json.tool sample-payload.json`

## Scope
- does not change Python version usage in `Makefile`
- does not touch broader stale test targets in this PR
