### PR TITLE
Add wallet funding requirement check to agent endpoint

### DIFF
--- a/server/fastapi_server.py
+++ b/server/fastapi_server.py
@@ -338,6 +338,14 @@ def create_fastapi_app() -> FastAPI:
             wallet_address=agent_request.context.address
         )
 
+        # Restrict agent usage to funded wallets
+        if portfolio.total_value_usd < 0.1:
+            return AgentMessage(
+                message="Please use a funded wallet (at least $0.10) to start using the agent",
+                pools=[],
+                tokens=[],
+            )
+
         try:
             response = await handle_agent_chat_request(
                 token_metadata_repo=token_metadata_repo,


### PR DESCRIPTION
## Summary
Added a minimum wallet funding requirement to the agent endpoint to prevent usage from unfunded wallets. Users must have at least $0.10 in portfolio value to use the agent.

## Changes
- Added validation check in `run_agent()` endpoint that verifies `portfolio.total_value_usd >= 0.1`
- Returns early with a user-friendly `AgentMessage` if the wallet is underfunded, preventing unnecessary agent execution
- Check occurs after portfolio retrieval but before agent chat request handling

## Implementation Details
The check is placed strategically after the portfolio is fetched from the repository but before the `handle_agent_chat_request()` call, ensuring we have wallet data available while minimizing wasted computation. The response maintains the `AgentMessage` contract with empty pools and tokens arrays, allowing the client to handle the rejection gracefully.

https://claude.ai/code/session_012Eg19FZC9pK9WVg9hR12CW