### PR TITLE
Remove wallet funding requirement from agent initialization

### DIFF
--- a/server/fastapi_server.py
+++ b/server/fastapi_server.py
@@ -338,14 +338,6 @@ def create_fastapi_app() -> FastAPI:
             wallet_address=agent_request.context.address
         )
 
-        # Restrict agent usage to funded wallets
-        if portfolio.total_value_usd < 0.01:
-            return AgentMessage(
-                message="Please use a funded wallet (at least $0.01) to start using the agent",
-                pools=[],
-                tokens=[],
-            )
-
         try:
             response = await handle_agent_chat_request(
                 token_metadata_repo=token_metadata_repo,


### PR DESCRIPTION
## Summary
Removes the minimum wallet funding check ($0.01 USD) that was previously blocking agent usage for unfunded wallets. This allows users to interact with the agent regardless of their current portfolio value.

## Changes
- Removed the portfolio funding validation check in the `run_agent` endpoint that was returning an early error message for wallets with less than $0.01 in total value
- Users can now initialize agent requests without requiring a pre-funded wallet

## Implementation Details
The removed check was preventing agent execution before the `handle_agent_chat_request` call. By removing this restriction, the agent can now process requests from all wallets, enabling use cases like portfolio analysis and research for users who haven't yet funded their accounts.

https://claude.ai/code/session_01At17KEceDKz5zQ2AapNiNd