### PR TITLE
Update Solana imports to use solders library

### DIFF
--- a/onchain/portfolio/solana_portfolio.py
+++ b/onchain/portfolio/solana_portfolio.py
@@ -3,7 +3,8 @@ import os
 
 from async_lru import alru_cache
 from solana.rpc.async_api import AsyncClient
-from solana.rpc.types import TokenAccountOpts, Pubkey
+from solana.rpc.models import TokenAccountOpts
+from solders.pubkey import Pubkey
 from solders.rpc.responses import RpcKeyedAccountJsonParsed
 
 from onchain.tokens.metadata import TokenMetadataRepo


### PR DESCRIPTION
## Summary
Updates import statements in the Solana portfolio module to use the `solders` library instead of deprecated `solana.rpc` types, improving compatibility with current Solana SDK versions.

## Changes
- Replaced `solana.rpc.types.TokenAccountOpts` with `solana.rpc.models.TokenAccountOpts`
- Replaced `solana.rpc.types.Pubkey` with `solders.pubkey.Pubkey`

## Details
This change aligns the codebase with the current Solana Python SDK structure where `Pubkey` has been moved to the `solders` library. The `TokenAccountOpts` import location was also updated to reflect the current SDK organization. These changes ensure compatibility with modern versions of the Solana SDK used throughout the BitQuant project.

https://claude.ai/code/session_01XSiH5Tmj7wE4r6hL9ySk3W